### PR TITLE
Wrong size of the struct

### DIFF
--- a/lib/dex.h
+++ b/lib/dex.h
@@ -121,7 +121,7 @@ typedef struct _DexClassDataItem {
   DexEncodedMethodItem** virtual_methods;
 } DexClassDataItem;
 
-typedef struct _DexTypeItem {
+typedef struct __attribute__((packed)) _DexTypeItem {
   Metadata meta;
   uint16_t type_idx;
 } DexTypeItem;


### PR DESCRIPTION
DXPARSE(_name,_type) use the size of the struct to load the data.
However, sizeof DexTypeItem is wrong due to the default alignment
in compiler. Therefore DXPARSE read two more extra bytes when reading
DexTypeItem which set the buffer position in wrong place.
